### PR TITLE
Fix reusable oversized bobber easy cast

### DIFF
--- a/FishingPlans/Bobbers.lua
+++ b/FishingPlans/Bobbers.lua
@@ -130,7 +130,7 @@ local function PickRandomBobber(bobbersetting)
 	for _,id in ipairs(bobbersetting) do
 		if (PlayerHasToy(id) and C_ToyBox.IsToyUsable(id)) then
 			if not PLANS:ItemCooldownOn(id) then
-				_, id = C_ToyBox.GetToyInfo(id);
+				id = C_ToyBox.GetToyInfo(id);
 				tinsert(baits, id);
 			end
 		end
@@ -143,19 +143,21 @@ end
 
 local function UseThisBobber(itemid, info)
 	local canuse;
+    local itemtype;
     if (info.toy) then
         canuse = false
 		if (PlayerHasToy(itemid) and C_ToyBox.IsToyUsable(itemid)) then
 			if not PLANS:ItemCooldownOn(itemid) then
-                _, itemid = C_ToyBox.GetToyInfo(itemid);
+                itemid = C_ToyBox.GetToyInfo(itemid);
                 canuse = true
+                itemtype = "toy"
             end
         end
     else
         canuse = (GetItemCount(itemid) > 0)
 	end
     if (canuse and not FL:HasBuff(info.spell)) then
-        return info.spell, canuse
+        return itemid, canuse, itemtype
     end
 
     -- return nil
@@ -182,10 +184,10 @@ local function SpecialBobberPlan()
 				return
 			end
 
-			local itemid, canuse = UseThisBobber(id, bobber);
+			local itemid, canuse, itemtype = UseThisBobber(id, bobber);
 			if canuse then
 				ClearSpecialBobberBuffs()
-				PLANS:AddEntry(itemid, bobber[CurLoc], "toy")
+				PLANS:AddEntry(itemid, bobber[CurLoc], itemtype)
 				return
 			end
 		end
@@ -270,7 +272,7 @@ if ( FBI.Debugging ) then
 			for _,id in ipairs(bobberkeys) do
 				if (PlayerHasToy(id) and C_ToyBox.IsToyUsable(id)) then
 					if not PLANS:ItemCooldownOn(id) then
-						_, id = C_ToyBox.GetToyInfo(id);
+						id = C_ToyBox.GetToyInfo(id);
 						tinsert(baits, id);
 					end
 				end

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,5 @@
 Version 1.26.5
+- Fix easy cast with Reusable Oversized Bobber by using the correct toy item ID (GitHub issue #2)
 - Fix calendar taint error in FishingExtravaganza.lua by avoiding restricted `sequenceType` comparisons.
 - Improve calendar event parsing resilience when title/type/texture fields are missing.
 - Fix `ADDON_ACTION_BLOCKED` from `RegisterForClicks` by deferring mouse click registration updates until out of combat.
@@ -1784,4 +1785,3 @@ Version 0.7.6
 
 Version 0.7.5
 - fix a bad memory leak on the outfit display page
-


### PR DESCRIPTION
Fixes #2

This corrects the toy item ID handling for bobber toys so easy cast works when the Reusable Oversized Bobber option is enabled.

Changes:
- use the correct return value from `C_ToyBox.GetToyInfo()` in `FishingPlans/Bobbers.lua`
- preserve the proper item type for toy bobbers
- add a changelog note for issue #2