### PR TITLE
Make fish watcher a movable standalone window

### DIFF
--- a/FishingWatcher.lua
+++ b/FishingWatcher.lua
@@ -9,10 +9,7 @@ local _
 local GSB = function(...) return FBI:GetSettingBool(...); end;
 
 local MAX_FISHINGWATCH_LINES = 1;
-local WATCHDRAGGER_SHOW_DELAY = 0.5;
-
 local ELAPSEDTIME_LINE = 1;
-local WATCHDRAGGER_FADE_TIME = 0.25;
 
 local ZoneFishingTime = 0;
 local TotalTimeFishing = nil;
@@ -227,32 +224,12 @@ function FWF:DisplayFishLine(fish, label, area)
     return label..line
 end
 
--- handle special frame actions
-local function FadingFinished()
-    FishingWatchHighlight:Hide();
-    FishingWatchTab:Hide();
-    FishingWatchTab.finishedFunc = nil;
-end
-
-local function ShowDraggerFrame()
-    UIFrameFadeIn(FishingWatchHighlight, WATCHDRAGGER_FADE_TIME, 0, 0.15);
-    UIFrameFadeIn(FishingWatchTab, WATCHDRAGGER_FADE_TIME, 0, 1.0);
-    FishingWatchFrame:EnableMouse(true);
-end
-
-local function HideDraggerFrame()
-    LW.OnDragStop(FishingWatchFrame);
-    FishingWatchFrame:EnableMouse(false);
-    if (FishingWatchTab:IsShown()) then
-        FishingWatchTab.finishedFunc = FadingFinished;
-        UIFrameFadeOut(FishingWatchHighlight, WATCHDRAGGER_FADE_TIME, 0.15, 0);
-        UIFrameFadeOut(FishingWatchTab, WATCHDRAGGER_FADE_TIME, 1.0, 0);
-    end
-end
-
 function FBI:ResetWatcherFrame(update)
     FishingWatchFrame:ClearAllPoints();
-    FishingWatchFrame:SetPoint("CENTER", "UIParent", "CENTER", 0, 0);
+    FishingWatchFrame:SetPoint("TOPRIGHT", "UIParent", "TOPRIGHT", -120, -220);
+    if FishingWatchFrame.SavePosition then
+        FishingWatchFrame:SavePosition();
+    end
     if ( update ) then
         FBI.WatchUpdate();
     end
@@ -565,7 +542,7 @@ end
 WatchEvents["VARIABLES_LOADED"] = function()
     ZoneFishingTime = 0;
 
-    FishingWatchTab.Text:SetText(FBConstants.NAME);
+    FishingWatchTab.Text:SetText(FBConstants.WATCHER_TAB);
     PanelTemplates_TabResize(FishingWatchTab, 10);
 
     FBI.OptionsFrame.HandleOptions(FBConstants.WATCHER_TAB, "Interface\\Icons\\Inv_Misc_Spyglass_03", WatcherOptions);
@@ -578,11 +555,15 @@ WatchEvents["VARIABLES_LOADED"] = function()
 
     LW:Embed(FishingWatchFrame)
     FishingWatchFrame:RegisterConfig(FishingBuddy_Player["WatcherLocation"], libwindow_names);
+    local location = FishingBuddy_Player["WatcherLocation"];
+    if location and location["solo_point"] == nil then
+        location["solo_x"] = -120;
+        location["solo_y"] = -220;
+        location["solo_point"] = "TOPRIGHT";
+    end
     FishingWatchFrame:RestorePosition();
     FishingWatchFrame:MakeDraggable();
-    FishingWatchFrame:EnableMouse(false);
-
-    local location = FishingBuddy_Player["WatcherLocation"];
+    FishingWatchFrame:EnableMouse(true);
     if location and location["grp_x"] == nil then
         for _,key in ipairs({"x", "y", "point", "scale"}) do
             location["grp_"..key] = location["solo_"..key];
@@ -900,7 +881,6 @@ function FBI:WatchUpdate()
 end
 
 local function HideOnEscape()
-    HideDraggerFrame();
 end
 
 local function TimerUpdate()
@@ -965,48 +945,9 @@ function FBEnvironment.Watcher_OnLoad(self)
     FWF:RegisterLineHandler(UpdateCoinLines, FWF.LAST_PRIORITY, false, true)
 end
 
-local isDragging = nil;
-local hover;
 FBEnvironment.Watcher_OnUpdate = function(self, elapsed)
     if ( self:IsVisible() ) then
         UpdateWatcherPosition();
-        if ( isDragging ) then
-            return;
-        end
-        if ( MouseIsOver(self) or MouseIsOver(FishingWatchTab) ) then
-            local xPos, yPos = GetCursorPosition();
-            if ( hover ) then
-                if ( hover.xPos == xPos and hover.yPos == yPos ) then
-                    hover.hoverTime = hover.hoverTime + elapsed;
-                else
-                    hover.hoverTime = 0;
-                    hover.xPos = xPos;
-                    hover.yPos = yPos;
-                end
-            else
-                hover = {};
-                hover.hoverTime = 0;
-                hover.xPos = xPos;
-                hover.yPos = yPos;
-            end
-            if ( hover.hoverTime > WATCHDRAGGER_SHOW_DELAY ) then
-                if (not hover.fadedin ) then
-                    ShowDraggerFrame();
-                end
-                hover.fadedin = 1;
-            end
-        else
-            if ( hover ) then
-                hover.hoverTime = hover.hoverTime + elapsed;
-                if ( hover.hoverTime > WATCHDRAGGER_SHOW_DELAY ) then
-                    HideDraggerFrame();
-                    hover = nil;
-                end
-            end
-        end
-    elseif ( hover ) then
-        HideDraggerFrame();
-        hover = nil;
     end
 end
 

--- a/FishingWatcher.xml
+++ b/FishingWatcher.xml
@@ -7,7 +7,7 @@
 	</Size>
     </FontString>
 
-    <Frame name="FishingWatchFrame" frameStrata="LOW" toplevel="true" enableMouse="false" clampedToScreen="true" movable="true" parent="UIParent" hidden="true">
+    <Frame name="FishingWatchFrame" frameStrata="MEDIUM" toplevel="true" enableMouse="true" clampedToScreen="true" movable="true" parent="UIParent" hidden="true">
 		<Scripts>
 			<OnLoad>
 				FBEnvironment.Watcher_OnLoad(self);
@@ -16,9 +16,86 @@
 				FBEnvironment.Watcher_OnUpdate(self, elapsed);
 			</OnUpdate>
 		</Scripts>
+		<Layers>
+			<Layer level="BACKGROUND">
+				<Texture name="$parentBackground" file="Interface\Tooltips\UI-Tooltip-Background">
+					<Color r="0.03" g="0.05" b="0.08" a="0.88"/>
+					<Anchors>
+						<Anchor point="TOPLEFT"/>
+						<Anchor point="BOTTOMRIGHT"/>
+					</Anchors>
+				</Texture>
+				<Texture name="$parentHeader" file="Interface\ChatFrame\ChatFrameBackground">
+					<Anchors>
+						<Anchor point="TOPLEFT"/>
+						<Anchor point="TOPRIGHT"/>
+					</Anchors>
+					<Size>
+						<AbsDimension x="0" y="30"/>
+					</Size>
+					<Color r="0.10" g="0.16" b="0.22" a="0.95"/>
+				</Texture>
+				<Texture name="$parentInset" file="Interface\ChatFrame\ChatFrameBackground">
+					<Color r="0" g="0" b="0" a="0.25"/>
+					<Size>
+						<AbsDimension x="0" y="0"/>
+					</Size>
+					<Anchors>
+						<Anchor point="TOPLEFT" relativePoint="TOPLEFT">
+							<AbsDimension x="3" y="-33"/>
+						</Anchor>
+						<Anchor point="BOTTOMRIGHT" relativePoint="BOTTOMRIGHT">
+							<AbsDimension x="-3" y="3"/>
+						</Anchor>
+					</Anchors>
+				</Texture>
+			</Layer>
+			<Layer level="BORDER">
+				<Texture name="$parentBorderTop" file="Interface\Buttons\WHITE8X8">
+					<Color r="0.36" g="0.47" b="0.58" a="0.9"/>
+					<Size>
+						<AbsDimension x="0" y="1"/>
+					</Size>
+					<Anchors>
+						<Anchor point="TOPLEFT"/>
+						<Anchor point="TOPRIGHT"/>
+					</Anchors>
+				</Texture>
+				<Texture name="$parentBorderBottom" file="Interface\Buttons\WHITE8X8">
+					<Color r="0.20" g="0.27" b="0.34" a="0.85"/>
+					<Size>
+						<AbsDimension x="0" y="1"/>
+					</Size>
+					<Anchors>
+						<Anchor point="BOTTOMLEFT"/>
+						<Anchor point="BOTTOMRIGHT"/>
+					</Anchors>
+				</Texture>
+				<Texture name="$parentBorderLeft" file="Interface\Buttons\WHITE8X8">
+					<Color r="0.20" g="0.27" b="0.34" a="0.85"/>
+					<Size>
+						<AbsDimension x="1" y="0"/>
+					</Size>
+					<Anchors>
+						<Anchor point="TOPLEFT"/>
+						<Anchor point="BOTTOMLEFT"/>
+					</Anchors>
+				</Texture>
+				<Texture name="$parentBorderRight" file="Interface\Buttons\WHITE8X8">
+					<Color r="0.20" g="0.27" b="0.34" a="0.85"/>
+					<Size>
+						<AbsDimension x="1" y="0"/>
+					</Size>
+					<Anchors>
+						<Anchor point="TOPRIGHT"/>
+						<Anchor point="BOTTOMRIGHT"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+		</Layers>
 		<Frames>
-			<Button name="FishingWatchTab" inherits="PanelTabButtonTemplate" hidden="true">
-				<Size x="64" y="32"/>
+			<Button name="FishingWatchTab" inherits="PanelTabButtonTemplate">
+				<Size x="120" y="32"/>
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeTo="FishingWatchFrame" relativePoint="TOPLEFT">
 						<AbsDimension x="0" y="2"/>

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,5 @@
 Version 1.26.5
+- Make the Fish Watcher behave as a movable standalone window with a visible header and side-position default.
 - Fix calendar taint error in FishingExtravaganza.lua by avoiding restricted `sequenceType` comparisons.
 - Improve calendar event parsing resilience when title/type/texture fields are missing.
 - Fix `ADDON_ACTION_BLOCKED` from `RegisterForClicks` by deferring mouse click registration updates until out of combat.
@@ -1784,4 +1785,3 @@ Version 0.7.6
 
 Version 0.7.5
 - fix a bad memory leak on the outfit display page
-


### PR DESCRIPTION
This PR moves the Fish Watcher into a cleaner standalone utility window.

Changes:
- make the watcher behave like a normal movable window instead of a hover-only overlay
- keep a visible watcher header so it can be repositioned easily
- change the default/reset watcher position to the side of the screen instead of centered
- add a clearer watcher backdrop with a darker header and clean borders
- add a changelog note in changes.txt

This keeps the existing watcher functionality while making it easier to keep visible without covering the middle of the screen.

<img width="1061" height="689" alt="image" src="https://github.com/user-attachments/assets/697a2f70-afcf-4ed8-899d-78eef91609f1" />
